### PR TITLE
Fixed #1 by limiting color stamp's length to 2.

### DIFF
--- a/GreatConsole/ConsoleColors.cs
+++ b/GreatConsole/ConsoleColors.cs
@@ -166,6 +166,11 @@ public static class ConsoleColors
             {
                 Advance();
                 colorStamp += currentChar;
+
+                if (colorStamp.Length >= 2)
+                {
+                    break;
+                }
             }
 
             switch (colorStamp.TrimEnd('\''))


### PR DESCRIPTION
The bad side is that it might cutoff part of text after it, but thats user's fault :)