### PR TITLE
Fix publish workflow yaml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publich To NuGet
+name: Publish to NuGet
 on:
   push:
     branches:
@@ -25,7 +25,7 @@ jobs:
           PROJECT_FILE_PATH: GreatConsole/GreatConsole.csproj
 
           # NuGet package id, used for version detection & defaults to project name
-          PACKAGE_NAME: Great Console
+          PACKAGE_NAME: GreatConsole
 
           # API key to authenticate with NuGet server
           NUGET_KEY: ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
## Summary
- fix typos in the publish workflow
- set `PACKAGE_NAME` to `GreatConsole`

## Testing
- `python3 - <<'PY'
import yaml
yaml.safe_load(open('.github/workflows/publish.yml'))
print('valid')
PY`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862919d272c83309d865d86b83becea